### PR TITLE
Always prefer codedir for hieradata

### DIFF
--- a/lib/beaker-hiera/helpers.rb
+++ b/lib/beaker-hiera/helpers.rb
@@ -53,7 +53,7 @@ module Beaker
         #
         # @return [String] Path to the hiera data directory
         def hiera_datadir(host)
-          host[:type] =~ /aio/ ? File.join(host.puppet['codedir'], 'hieradata') : host[:hieradatadir]
+          File.join(host.puppet['codedir'], 'hieradata')
         end
 
       end

--- a/spec/beaker-hiera/helpers_spec.rb
+++ b/spec/beaker-hiera/helpers_spec.rb
@@ -16,22 +16,13 @@ describe ClassMixedWithDSLHelpers do
 
   describe "#write_hiera_config_on" do
     let(:hierarchy) { [ 'nodes/%{::fqdn}', 'common' ] }
-    it 'on FOSS host' do
-      host = make_host('testhost', { :platform => 'ubuntu' } )
+
+    it 'on host' do
       hiera_config = '/usr/face'
       allow( host ).to receive( :puppet ) { { 'hiera_config' => hiera_config } }
       expect(subject).to receive(:create_remote_file).with(host, hiera_config, /#{host[:hieradatadir]}/)
       subject.write_hiera_config_on(host, hierarchy)
     end
-
-    it 'on PE host' do
-      host = make_host('testhost', { :platform => 'ubuntu', :type => 'pe' } )
-      hiera_config = '/usr/face'
-      allow( host ).to receive( :puppet ) { { 'hiera_config' => hiera_config } }
-      expect(subject).to receive(:create_remote_file).with(host, hiera_config, /#{host[:hieradatadir]}/)
-      subject.write_hiera_config_on(host, hierarchy)
-    end
-
   end
 
   describe "#write_hiera_config" do
@@ -47,14 +38,8 @@ describe ClassMixedWithDSLHelpers do
 
   describe "#copy_hiera_data_to" do
     let(:path) { 'spec/fixtures/hieradata' }
-    it 'on FOSS host' do
-      host = make_host('testhost', { :platform => 'ubuntu' } )
-      expect(subject).to receive(:scp_to).with(host, File.expand_path(path), host[:hieradatadir])
-      subject.copy_hiera_data_to(host, path)
-    end
 
-    it 'on PE host' do
-      host = make_host('testhost', { :platform => 'ubuntu', :type => 'pe' } )
+    it 'on host' do
       expect(subject).to receive(:scp_to).with(host, File.expand_path(path), host[:hieradatadir])
       subject.copy_hiera_data_to(host, path)
     end

--- a/spec/beaker-hiera/helpers_spec.rb
+++ b/spec/beaker-hiera/helpers_spec.rb
@@ -12,7 +12,6 @@ end
 
 describe ClassMixedWithDSLHelpers do
   let( :host  ) { make_host( 'master', :roles => %w( master agent default) ) }
-  let( :hosts ) { [ host ] }
 
   describe "#write_hiera_config_on" do
     let(:hierarchy) { [ 'nodes/%{::fqdn}', 'common' ] }
@@ -28,7 +27,6 @@ describe ClassMixedWithDSLHelpers do
   describe "#write_hiera_config" do
     let(:hierarchy) { [ 'nodes/%{::fqdn}', 'common' ] }
     it 'delegates to #write_hiera_config_on with the default host' do
-      allow( subject ).to receive( :hosts ).and_return( hosts )
       allow( subject ).to receive( :default ).and_return( host )
       expect( subject ).to receive( :write_hiera_config_on ).with( host, hierarchy).once
       subject.write_hiera_config( hierarchy )
@@ -48,7 +46,6 @@ describe ClassMixedWithDSLHelpers do
   describe "#copy_hiera_data" do
     let(:path) { 'spec/fixtures/hieradata' }
     it 'delegates to #copy_hiera_data_to with the default host' do
-      allow( subject ).to receive( :hosts ).and_return( hosts )
       allow( subject ).to receive( :default ).and_return( host )
       expect( subject ).to receive( :copy_hiera_data_to ).with( host, path).once
       subject.copy_hiera_data( path )


### PR DESCRIPTION
This dynamically detects the codedir on the host via the settings which should always work. The other method uses hardcoded values and can go out of sync. This is a more reliable method.