### PR TITLE
Indicate the project is not EOL and add example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
-# NOTE: This project is officially EOL.
-
-As of Beaker 4.0, beaker-hiera is officially End-Of-Life and has been archived. If you need Hiera DSL methods for Beaker, please find them in <github.com/puppetlabs/beaker-puppet>.
-
 # beaker-hiera
-Beaker Hiera DSL Extension Library!
+
+Beaker Hiera DSL Extension Library! This allows to easily use Hiera data in acceptance tests.
+
+```ruby
+hierarchy = [
+  'fqdn/%{fqdn}.yaml',
+  'os/%{os.family}/%{os.release.major}.yaml',
+  'os/%{os.family}.yaml',
+  'common.yaml',
+]
+write_hiera_config_on(host, hierarchy)
+copy_hiera_data_to(host, 'spec/acceptance/hieradata')
+```


### PR DESCRIPTION
The actual helper methods were never migrated to beaker-puppet. That's why this gem still has a purpose. An example is also easy to get started.