### PR TITLE
Require Ruby ~> 2.4

### DIFF
--- a/beaker-hiera.gemspec
+++ b/beaker-hiera.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.required_ruby_version = '~> 2.4'
+
   # Testing dependencies
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
This is what's tested and thus the only thing that can be guaranteed.