### PR TITLE
Convert to Hiera 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,32 @@
 
 Beaker Hiera DSL Extension Library! This allows to easily use Hiera data in acceptance tests.
 
+## Usage
+
+The `write_hiera_config_on` method is the most important one.
+It writes the `hiera.yaml` file to the specified host or hosts.
+The version is always set to 5, as well as a default `datadir`.
+The `hierarchy` is directly what the [documentation](https://www.puppet.com/docs/puppet/7/hiera_config_yaml_5.html) specifies.
+It is then important to also copy the data from a local directory to the same host or hosts.
+
 ```ruby
 hierarchy = [
-  'fqdn/%{fqdn}.yaml',
-  'os/%{os.family}/%{os.release.major}.yaml',
-  'os/%{os.family}.yaml',
-  'common.yaml',
+  {
+    'name' => 'Per-node data',
+    'path' => 'fqdn/%{facts.networking.fqdn}.yaml',
+  },
+  {
+    'name' => 'OS family version data',
+    'path' => 'family/%{facts.os.family}/%{facts.os.release.major}.yaml',
+  },
+  {
+    'name' => 'OS family data',
+    'path' => 'family/%{facts.os.family}.yaml',
+  },
+  {
+    'name' => 'Common data',
+    'path' => 'common.yaml',
+  },
 ]
 write_hiera_config_on(host, hierarchy)
 copy_hiera_data_to(host, 'spec/acceptance/hieradata')

--- a/lib/beaker-hiera/helpers.rb
+++ b/lib/beaker-hiera/helpers.rb
@@ -9,17 +9,19 @@ module Beaker
         # @param [Host, Array<Host>, String, Symbol] host
         #   One or more hosts to act upon, or a role (String or Symbol) that
         #   identifies one or more hosts.
-        # @param [Array] hierarchy
-        #   One or more hierarchy paths
+        # @param [Array[Hash[String, String]]] hierarchy
+        #   The hierachy as specified in Hiera config YAML version 5
+        #
+        # @see https://www.puppet.com/docs/puppet/7/hiera_config_yaml_5.html
         def write_hiera_config_on(host, hierarchy)
           block_on host do |hst|
             hiera_config = {
-              backends: 'yaml',
-              yaml: {
-                datadir: hiera_datadir(hst),
+              'version' => 5,
+              'defaults' => {
+                'datadir' => hiera_datadir(hst),
+                'data_hash' => 'yaml_data',
               },
-              hierarchy: hierarchy,
-              logger: 'console',
+              'hierarchy' => hierarchy,
             }
             create_remote_file hst, hst.puppet['hiera_config'], hiera_config.to_yaml
           end

--- a/spec/beaker-hiera/helpers_spec.rb
+++ b/spec/beaker-hiera/helpers_spec.rb
@@ -19,7 +19,7 @@ describe ClassMixedWithDSLHelpers do
   end
 
   describe '#write_hiera_config_on' do
-    let(:hierarchy) { ['nodes/%{::fqdn}', 'common'] }
+    let(:hierarchy) { [{ 'name' => 'common', 'path' => 'common.yaml' }] }
 
     it 'on host' do
       expect(subject).to receive(:create_remote_file).with(host, '/usr/face', %r{datadir: "/usr/code/hieradata"})
@@ -28,7 +28,7 @@ describe ClassMixedWithDSLHelpers do
   end
 
   describe '#write_hiera_config' do
-    let(:hierarchy) { ['nodes/%{::fqdn}', 'common'] }
+    let(:hierarchy) { [{ 'name' => 'common', 'path' => 'common.yaml' }] }
 
     it 'delegates to #write_hiera_config_on with the default host' do
       expect(subject).to receive(:default).and_return(host)


### PR DESCRIPTION
Until now the deprecated Hiera 3 config was deprecated. This rewrites it to only generate Hiera 5 version.