### PR TITLE
CI: Generate matrix dynamically / drop simplecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -6,35 +7,30 @@ on:
     branches:
       - master
 
-env:
-  BUNDLE_WITHOUT: release
-
 jobs:
-  rubocop:
-    runs-on: ubuntu-latest
+  rubocop_and_matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      ruby: ${{ steps.ruby.outputs.versions }}
     steps:
       - uses: actions/checkout@v4
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rake rubocop
+      - id: ruby
+        uses: voxpupuli/ruby-version@v1
+
   spec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    needs: rubocop_and_matrix
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - ruby: "2.7"
-            coverage: "yes"
-          - ruby: "3.0"
-          - ruby: "3.1"
-          - ruby: "3.2"
-          - ruby: "3.3"
-    env:
-      COVERAGE: ${{ matrix.coverage }}
+        ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}
     name: RSpec - Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v4
@@ -50,9 +46,9 @@ jobs:
 
   tests:
     needs:
+      - rubocop_and_matrix
       - spec
-      - rubocop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Test suite
     steps:
       - run: echo Test suite completed

--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,0 @@
-SimpleCov.configure do
-  add_filter 'spec/'
-  add_filter 'vendor/'
-  add_filter do |file|
-    file.lines_of_code < 10
-  end
-end
-
-SimpleCov.start if ENV['BEAKER_HIERA_COVERAGE']

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
 
-group :release do
-  gem 'faraday-retry', require: false
-  gem 'github_changelog_generator', require: false
+group :release, optional: true do
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
 end

--- a/beaker-hiera.gemspec
+++ b/beaker-hiera.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'simplecov', '~> 0.22.0'
   s.add_development_dependency 'voxpupuli-rubocop', '~> 2.8.0'
 
   # Run time dependencies

--- a/beaker-hiera.gemspec
+++ b/beaker-hiera.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'voxpupuli-rubocop', '~> 2.8.0'
 
   # Run time dependencies
-  s.add_runtime_dependency 'beaker', '>= 4', '< 7'
+  s.add_runtime_dependency 'beaker', '>= 4', '< 8'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'simplecov'
 require 'beaker-hiera'
 
 RSpec.configure do |config|


### PR DESCRIPTION
We did the same in other gems. We don't use simplecov, so we remove the unused dependency.

---

also contains https://github.com/voxpupuli/beaker-hiera/pull/42